### PR TITLE
fix: typo jsDelivr

### DIFF
--- a/uPic/en.lproj/Localizable.strings
+++ b/uPic/en.lproj/Localizable.strings
@@ -104,7 +104,7 @@
 "Body Data" = "Body Data";
 "Client ID" = "Client ID";
 "Save Key" = "Save Key";
-"Use CDN" = "Use jsDeliver CDN to speed up access";
+"Use CDN" = "Use jsDelivr CDN to speed up access";
 "Version" = "Version";
 "Email" = "Email";
 "Anonymous" = "Anonymous";

--- a/uPic/zh-Hans.lproj/Localizable.strings
+++ b/uPic/zh-Hans.lproj/Localizable.strings
@@ -104,7 +104,7 @@
 "Body Data" = "Body 数据";
 "Client ID" = "Client ID";
 "Save Key" = "保存路径";
-"Use CDN" = "使用 jsDeliver CDN 加速访问";
+"Use CDN" = "使用 jsDelivr CDN 加速访问";
 "Version" = "版本";
 "Email" = "邮箱";
 "Anonymous" = "匿名";


### PR DESCRIPTION
## Summary of this pull request
修复拼写错误：`jsDeliver =>jsDelivr`
## Does this solve an existing issue? If so, add a link to it

## Steps to test this feature

## Screenshots

## Additional info
