### PR TITLE
Fix installation instructions in README.md

### DIFF
--- a/README-cn.md
+++ b/README-cn.md
@@ -38,7 +38,7 @@
 ### 下载安装
 #### 1.Homebrew(推荐):
 ```
-brew cask install upic
+brew install --cask upic
 ```
 #### 2.手动
 从 [Github release](https://github.com/gee1k/uPic/releases) 下载。

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 
 ### 1. Homebrew(Recommend):
 ```
-brew cask install upic
+brew install --cask upic
 ```
 ### 2. Download from github
  Click [release](https://github.com/gee1k/uPic/releases) to download.


### PR DESCRIPTION
## Summary of this pull request

Fix error when installing using latest Homebrew. This is not a bug of this app, but README.md needs to be fixed.

## Screenshots
![Calling brew cask install is disabled](https://user-images.githubusercontent.com/8146876/103143401-732daf00-4758-11eb-9117-9ca9ed521c36.png)


## Additional info
- macOS 10.15.7
- Homebrew 2.7.0