### PR TITLE
替换部分pod库为SPM包

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -7,14 +7,6 @@ target 'uPic' do
 # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
 use_frameworks!
 
-    pod 'SwiftyJSON'
-    pod 'Alamofire'
-    pod 'MASShortcut'
-    pod 'CryptoSwift', :git => "https://github.com/krzyzanowskim/CryptoSwift", :branch => "master"
-    pod "SwiftyXMLParser", :git => 'https://github.com/yahoojapan/SwiftyXMLParser.git'
-    pod 'Kingfisher'
-    pod 'SnapKit'
-    pod 'LoginServiceKit', :git => 'https://github.com/Clipy/LoginServiceKit.git'
     pod "libminipng"
     pod 'WCDB.swift'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,78 +1,29 @@
 PODS:
-  - Alamofire (5.4.4)
-  - CryptoSwift (1.4.1)
-  - Kingfisher (6.3.1)
   - libminipng (0.5.6)
-  - LoginServiceKit (2.2.1)
-  - MASShortcut (2.4.0)
-  - SnapKit (5.0.1)
   - SQLiteRepairKit (1.2.2):
     - WCDBOptimizedSQLCipher (~> 1.2.0)
-  - SwiftyJSON (5.0.1)
-  - SwiftyXMLParser (5.5.0)
   - WCDB.swift (1.0.8.2):
     - SQLiteRepairKit (~> 1.2.0)
     - WCDBOptimizedSQLCipher (~> 1.2.0)
   - WCDBOptimizedSQLCipher (1.2.1)
 
 DEPENDENCIES:
-  - Alamofire
-  - CryptoSwift (from `https://github.com/krzyzanowskim/CryptoSwift`, branch `master`)
-  - Kingfisher
   - libminipng
-  - LoginServiceKit (from `https://github.com/Clipy/LoginServiceKit.git`)
-  - MASShortcut
-  - SnapKit
-  - SwiftyJSON
-  - SwiftyXMLParser (from `https://github.com/yahoojapan/SwiftyXMLParser.git`)
   - WCDB.swift
 
 SPEC REPOS:
   trunk:
-    - Alamofire
-    - Kingfisher
     - libminipng
-    - MASShortcut
-    - SnapKit
     - SQLiteRepairKit
-    - SwiftyJSON
     - WCDB.swift
     - WCDBOptimizedSQLCipher
 
-EXTERNAL SOURCES:
-  CryptoSwift:
-    :branch: master
-    :git: https://github.com/krzyzanowskim/CryptoSwift
-  LoginServiceKit:
-    :git: https://github.com/Clipy/LoginServiceKit.git
-  SwiftyXMLParser:
-    :git: https://github.com/yahoojapan/SwiftyXMLParser.git
-
-CHECKOUT OPTIONS:
-  CryptoSwift:
-    :commit: 13af4db1aa39e9c7054df442e1ca6227a1aa3927
-    :git: https://github.com/krzyzanowskim/CryptoSwift
-  LoginServiceKit:
-    :commit: f93f5eb8f9270f160318184a7ffc6a8890606d61
-    :git: https://github.com/Clipy/LoginServiceKit.git
-  SwiftyXMLParser:
-    :commit: 41900bb1882e704a25d4946f2dbad71b4bb02b8f
-    :git: https://github.com/yahoojapan/SwiftyXMLParser.git
-
 SPEC CHECKSUMS:
-  Alamofire: f3b09a368f1582ab751b3fff5460276e0d2cf5c9
-  CryptoSwift: 0bc800a7e6a24c4fc9ebeab97d44b0d5f73a78bd
-  Kingfisher: 016c8b653a35add51dd34a3aba36b580041acc74
   libminipng: a44c35d06b9d54d6640acdf97f4500c034748abb
-  LoginServiceKit: e39022a6ea6169b3716fc3c43e89b2e7fd12f222
-  MASShortcut: d9e4909e878661cc42877cc9d6efbe638273ab57
-  SnapKit: 97b92857e3df3a0c71833cce143274bf6ef8e5eb
   SQLiteRepairKit: 35aaae5a8838adb85f5b1eb4d796055be6060a4b
-  SwiftyJSON: 2f33a42c6fbc52764d96f13368585094bfd8aa5e
-  SwiftyXMLParser: 027d9e6fb54a38d95dccec025bcea9693f699c47
   WCDB.swift: 05d509d7a0e60fb6e11c34eb7e4027c0fab5849f
   WCDBOptimizedSQLCipher: baf44493b0c7a3d49e97bc5b64a3856f6428ddd1
 
-PODFILE CHECKSUM: 5805b359b360efbaba02725567dda3b519766521
+PODFILE CHECKSUM: 89b7752c39972dc59c8b267c69126165a8916a2c
 
 COCOAPODS: 1.11.2

--- a/uPic.xcodeproj/project.pbxproj
+++ b/uPic.xcodeproj/project.pbxproj
@@ -90,7 +90,6 @@
 		1690E7ED22BF2E4F00FC81F8 /* QiniuUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1690E7EC22BF2E4F00FC81F8 /* QiniuUtil.swift */; };
 		16995A3422B6008000B1F923 /* UpYunHostConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16995A3322B6008000B1F923 /* UpYunHostConfig.swift */; };
 		16995A3622B6026500B1F923 /* UpYunUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16995A3522B6026500B1F923 /* UpYunUtil.swift */; };
-		169C5C1726FB924F0045CBEF /* SotoS3 in Frameworks */ = {isa = PBXBuildFile; productRef = 169C5C1626FB924F0045CBEF /* SotoS3 */; };
 		169F073722AF4549008E8525 /* AdvancedPreferencesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 169F073322AF4549008E8525 /* AdvancedPreferencesViewController.swift */; };
 		169F073922AF4549008E8525 /* GeneralPreferencesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 169F073522AF4549008E8525 /* GeneralPreferencesViewController.swift */; };
 		169F073A22AF4549008E8525 /* AboutPreferencesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 169F073622AF4549008E8525 /* AboutPreferencesViewController.swift */; };
@@ -144,6 +143,15 @@
 		4BEFD813238BB2F200BBE64D /* HistoryPreviewCustomScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BEFD812238BB2F200BBE64D /* HistoryPreviewCustomScrollView.swift */; };
 		8E879700A97E9294450D524F /* Pods_uPic.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A116EF79D38D9092D34EFCF5 /* Pods_uPic.framework */; };
 		96223BB126F6214B00EA33F7 /* FinderUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16ECAA952413B6C200F9236B /* FinderUtil.swift */; };
+		964198B62729A6BA0001AB97 /* SwiftyJSON in Frameworks */ = {isa = PBXBuildFile; productRef = 964198B52729A6BA0001AB97 /* SwiftyJSON */; };
+		964198B92729A7370001AB97 /* SotoS3 in Frameworks */ = {isa = PBXBuildFile; productRef = 964198B82729A7370001AB97 /* SotoS3 */; };
+		964198BC2729A75B0001AB97 /* MASShortcut in Frameworks */ = {isa = PBXBuildFile; productRef = 964198BB2729A75B0001AB97 /* MASShortcut */; };
+		964198C02729A7E30001AB97 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 964198BF2729A7E30001AB97 /* Alamofire */; };
+		964198C22729A7E90001AB97 /* CryptoSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 964198C12729A7E90001AB97 /* CryptoSwift */; };
+		964198C42729A7EC0001AB97 /* SwiftyXMLParser in Frameworks */ = {isa = PBXBuildFile; productRef = 964198C32729A7EC0001AB97 /* SwiftyXMLParser */; };
+		964198C62729A7F00001AB97 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 964198C52729A7F00001AB97 /* Kingfisher */; };
+		964198C82729A7F60001AB97 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 964198C72729A7F60001AB97 /* SnapKit */; };
+		964198D22729AB170001AB97 /* LaunchAtLogin in Frameworks */ = {isa = PBXBuildFile; productRef = 964198D12729AB170001AB97 /* LaunchAtLogin */; };
 		965A5E5225ADBD8F00AB88FF /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 1623612522AB951E00E4025C /* Localizable.strings */; };
 		965E817125B721650031A01F /* WelcomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 965E817025B721650031A01F /* WelcomeViewController.swift */; };
 		965E819B25B7274E0031A01F /* WelcomeWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 965E819A25B7274E0031A01F /* WelcomeWindowController.swift */; };
@@ -393,8 +401,16 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				964198BC2729A75B0001AB97 /* MASShortcut in Frameworks */,
+				964198B92729A7370001AB97 /* SotoS3 in Frameworks */,
+				964198B62729A6BA0001AB97 /* SwiftyJSON in Frameworks */,
+				964198C62729A7F00001AB97 /* Kingfisher in Frameworks */,
+				964198C42729A7EC0001AB97 /* SwiftyXMLParser in Frameworks */,
+				964198C02729A7E30001AB97 /* Alamofire in Frameworks */,
 				8E879700A97E9294450D524F /* Pods_uPic.framework in Frameworks */,
-				169C5C1726FB924F0045CBEF /* SotoS3 in Frameworks */,
+				964198C22729A7E90001AB97 /* CryptoSwift in Frameworks */,
+				964198D22729AB170001AB97 /* LaunchAtLogin in Frameworks */,
+				964198C82729A7F60001AB97 /* SnapKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -908,7 +924,15 @@
 			);
 			name = uPic;
 			packageProductDependencies = (
-				169C5C1626FB924F0045CBEF /* SotoS3 */,
+				964198B52729A6BA0001AB97 /* SwiftyJSON */,
+				964198B82729A7370001AB97 /* SotoS3 */,
+				964198BB2729A75B0001AB97 /* MASShortcut */,
+				964198BF2729A7E30001AB97 /* Alamofire */,
+				964198C12729A7E90001AB97 /* CryptoSwift */,
+				964198C32729A7EC0001AB97 /* SwiftyXMLParser */,
+				964198C52729A7F00001AB97 /* Kingfisher */,
+				964198C72729A7F60001AB97 /* SnapKit */,
+				964198D12729AB170001AB97 /* LaunchAtLogin */,
 			);
 			productName = uPic;
 			productReference = 16EC9A0222ABBBB4001B6C89 /* uPic.app */;
@@ -998,7 +1022,15 @@
 			);
 			mainGroup = 16A6DC4B22AA375700813706;
 			packageReferences = (
-				169C5C1526FB924F0045CBEF /* XCRemoteSwiftPackageReference "soto" */,
+				9630C4222729A05E009E8735 /* XCRemoteSwiftPackageReference "Alamofire" */,
+				9630C4232729A096009E8735 /* XCRemoteSwiftPackageReference "CryptoSwift" */,
+				9630C4242729A0B0009E8735 /* XCRemoteSwiftPackageReference "SwiftyXMLParser" */,
+				9630C4252729A0D0009E8735 /* XCRemoteSwiftPackageReference "Kingfisher" */,
+				9630C4262729A0EA009E8735 /* XCRemoteSwiftPackageReference "SnapKit" */,
+				964198B42729A6BA0001AB97 /* XCRemoteSwiftPackageReference "SwiftyJSON" */,
+				964198B72729A7370001AB97 /* XCRemoteSwiftPackageReference "soto" */,
+				964198BA2729A75A0001AB97 /* XCRemoteSwiftPackageReference "MASShortcut" */,
+				964198D02729AB170001AB97 /* XCRemoteSwiftPackageReference "LaunchAtLogin" */,
 			);
 			productRefGroup = 16A6DC4B22AA375700813706;
 			projectDirPath = "";
@@ -1432,7 +1464,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -1489,7 +1521,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = macosx;
@@ -1502,7 +1534,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = B31C410193F6C634ECBC8F5F /* Pods-uPic.debug.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -1511,14 +1543,14 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 12;
-				DEVELOPMENT_TEAM = W863J6W8DZ;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/uPic/Supporting Files/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.svend.uPic.macos;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1533,7 +1565,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = FA1B39CC17103449CC5099AD /* Pods-uPic.release.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -1542,14 +1574,14 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 12;
-				DEVELOPMENT_TEAM = W863J6W8DZ;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/uPic/Supporting Files/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.svend.uPic.macos;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1568,7 +1600,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 12;
-				DEVELOPMENT_TEAM = W863J6W8DZ;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = uPicFinderExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1576,7 +1608,7 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.svend.uPic.macos.uPicFinderExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1595,7 +1627,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 12;
-				DEVELOPMENT_TEAM = W863J6W8DZ;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = uPicFinderExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1603,7 +1635,7 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.svend.uPic.macos.uPicFinderExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1621,7 +1653,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 12;
-				DEVELOPMENT_TEAM = W863J6W8DZ;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = uPicShareExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1629,7 +1661,7 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.svend.uPic.macos.uPicShareExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1647,7 +1679,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 12;
-				DEVELOPMENT_TEAM = W863J6W8DZ;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = uPicShareExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1655,7 +1687,7 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.svend.uPic.macos.uPicShareExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1706,7 +1738,55 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		169C5C1526FB924F0045CBEF /* XCRemoteSwiftPackageReference "soto" */ = {
+		9630C4222729A05E009E8735 /* XCRemoteSwiftPackageReference "Alamofire" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Alamofire/Alamofire";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.0.0;
+			};
+		};
+		9630C4232729A096009E8735 /* XCRemoteSwiftPackageReference "CryptoSwift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/krzyzanowskim/CryptoSwift";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.0;
+			};
+		};
+		9630C4242729A0B0009E8735 /* XCRemoteSwiftPackageReference "SwiftyXMLParser" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/yahoojapan/SwiftyXMLParser";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.0.0;
+			};
+		};
+		9630C4252729A0D0009E8735 /* XCRemoteSwiftPackageReference "Kingfisher" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/onevcat/Kingfisher";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 7.0.0;
+			};
+		};
+		9630C4262729A0EA009E8735 /* XCRemoteSwiftPackageReference "SnapKit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/SnapKit/SnapKit";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.0.0;
+			};
+		};
+		964198B42729A6BA0001AB97 /* XCRemoteSwiftPackageReference "SwiftyJSON" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/SwiftyJSON/SwiftyJSON";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.0.0;
+			};
+		};
+		964198B72729A7370001AB97 /* XCRemoteSwiftPackageReference "soto" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/soto-project/soto.git";
 			requirement = {
@@ -1714,13 +1794,69 @@
 				minimumVersion = 5.0.0;
 			};
 		};
+		964198BA2729A75A0001AB97 /* XCRemoteSwiftPackageReference "MASShortcut" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/shpakovski/MASShortcut";
+			requirement = {
+				branch = master;
+				kind = branch;
+			};
+		};
+		964198D02729AB170001AB97 /* XCRemoteSwiftPackageReference "LaunchAtLogin" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/sindresorhus/LaunchAtLogin";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 4.0.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		169C5C1626FB924F0045CBEF /* SotoS3 */ = {
+		964198B52729A6BA0001AB97 /* SwiftyJSON */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 169C5C1526FB924F0045CBEF /* XCRemoteSwiftPackageReference "soto" */;
+			package = 964198B42729A6BA0001AB97 /* XCRemoteSwiftPackageReference "SwiftyJSON" */;
+			productName = SwiftyJSON;
+		};
+		964198B82729A7370001AB97 /* SotoS3 */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 964198B72729A7370001AB97 /* XCRemoteSwiftPackageReference "soto" */;
 			productName = SotoS3;
+		};
+		964198BB2729A75B0001AB97 /* MASShortcut */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 964198BA2729A75A0001AB97 /* XCRemoteSwiftPackageReference "MASShortcut" */;
+			productName = MASShortcut;
+		};
+		964198BF2729A7E30001AB97 /* Alamofire */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 9630C4222729A05E009E8735 /* XCRemoteSwiftPackageReference "Alamofire" */;
+			productName = Alamofire;
+		};
+		964198C12729A7E90001AB97 /* CryptoSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 9630C4232729A096009E8735 /* XCRemoteSwiftPackageReference "CryptoSwift" */;
+			productName = CryptoSwift;
+		};
+		964198C32729A7EC0001AB97 /* SwiftyXMLParser */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 9630C4242729A0B0009E8735 /* XCRemoteSwiftPackageReference "SwiftyXMLParser" */;
+			productName = SwiftyXMLParser;
+		};
+		964198C52729A7F00001AB97 /* Kingfisher */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 9630C4252729A0D0009E8735 /* XCRemoteSwiftPackageReference "Kingfisher" */;
+			productName = Kingfisher;
+		};
+		964198C72729A7F60001AB97 /* SnapKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 9630C4262729A0EA009E8735 /* XCRemoteSwiftPackageReference "SnapKit" */;
+			productName = SnapKit;
+		};
+		964198D12729AB170001AB97 /* LaunchAtLogin */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 964198D02729AB170001AB97 /* XCRemoteSwiftPackageReference "LaunchAtLogin" */;
+			productName = LaunchAtLogin;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/uPic.xcodeproj/project.pbxproj
+++ b/uPic.xcodeproj/project.pbxproj
@@ -190,15 +190,6 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		16EA205922AF8C680006FB9C /* CopyFiles */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = Contents/Library/LoginItems;
-			dstSubfolderSpec = 1;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		16F7467D22E994A300480A62 /* Embed App Extensions */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -911,8 +902,8 @@
 				16A6DC5022AA375700813706 /* Sources */,
 				16A6DC5122AA375700813706 /* Frameworks */,
 				16A6DC5222AA375700813706 /* Resources */,
+				964DA808272AF5630003304C /* Copy “Launch at Login Helper” */,
 				8B11FF3895E709812B771F7E /* [CP] Embed Pods Frameworks */,
-				16EA205922AF8C680006FB9C /* CopyFiles */,
 				16F7467D22E994A300480A62 /* Embed App Extensions */,
 				1613D88B25C98273009E348A /* ShellScript */,
 			);
@@ -1118,6 +1109,24 @@
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-uPic/Pods-uPic-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
+		};
+		964DA808272AF5630003304C /* Copy “Launch at Login Helper” */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Copy “Launch at Login Helper”";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${BUILT_PRODUCTS_DIR}/LaunchAtLogin_LaunchAtLogin.bundle/Contents/Resources/copy-helper-swiftpm.sh\"\n";
 		};
 		AF16EB1F68345467E01767BE /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/uPic.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/uPic.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,15 +2,6 @@
   "object": {
     "pins": [
       {
-        "package": "Alamofire",
-        "repositoryURL": "https://github.com/Alamofire/Alamofire",
-        "state": {
-          "branch": null,
-          "revision": "d120af1e8638c7da36c8481fd61a66c0c08dc4fc",
-          "version": "5.4.4"
-        }
-      },
-      {
         "package": "async-http-client",
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
@@ -20,57 +11,12 @@
         }
       },
       {
-        "package": "CryptoSwift",
-        "repositoryURL": "https://github.com/krzyzanowskim/CryptoSwift",
-        "state": {
-          "branch": null,
-          "revision": "4b0565384d3c4c588af09e660535b2c7c9bf5b39",
-          "version": "1.4.2"
-        }
-      },
-      {
         "package": "jmespath.swift",
         "repositoryURL": "https://github.com/adam-fowler/jmespath.swift.git",
         "state": {
           "branch": null,
           "revision": "4a166ea71f0d9e9cc3523fc3dee516080a4c36a0",
           "version": "1.0.0"
-        }
-      },
-      {
-        "package": "Kingfisher",
-        "repositoryURL": "https://github.com/onevcat/Kingfisher",
-        "state": {
-          "branch": null,
-          "revision": "318e319998bf555c3e914d5c3adb6da05af86a32",
-          "version": "7.1.1"
-        }
-      },
-      {
-        "package": "LaunchAtLogin",
-        "repositoryURL": "https://github.com/sindresorhus/LaunchAtLogin",
-        "state": {
-          "branch": null,
-          "revision": "e8171b3e38a2816f579f58f3dac1522aa39efe41",
-          "version": "4.2.0"
-        }
-      },
-      {
-        "package": "MASShortcut",
-        "repositoryURL": "https://github.com/shpakovski/MASShortcut",
-        "state": {
-          "branch": "master",
-          "revision": "57ccb018863b328a22298a275593a1d87ab4db24",
-          "version": null
-        }
-      },
-      {
-        "package": "SnapKit",
-        "repositoryURL": "https://github.com/SnapKit/SnapKit",
-        "state": {
-          "branch": null,
-          "revision": "d458564516e5676af9c70b4f4b2a9178294f1bc6",
-          "version": "5.0.1"
         }
       },
       {
@@ -152,24 +98,6 @@
           "branch": null,
           "revision": "e7f5278a26442dc46783ba7e063643d524e414a0",
           "version": "1.11.3"
-        }
-      },
-      {
-        "package": "SwiftyJSON",
-        "repositoryURL": "https://github.com/SwiftyJSON/SwiftyJSON",
-        "state": {
-          "branch": null,
-          "revision": "b3dcd7dbd0d488e1a7077cb33b00f2083e382f07",
-          "version": "5.0.1"
-        }
-      },
-      {
-        "package": "SwiftyXMLParser",
-        "repositoryURL": "https://github.com/yahoojapan/SwiftyXMLParser",
-        "state": {
-          "branch": null,
-          "revision": "ad5eeeaf7797f69e26943aaa53c81c6a9fdaa516",
-          "version": "5.5.0"
         }
       }
     ]

--- a/uPic.xcodeproj/xcshareddata/xcschemes/uPic.xcscheme
+++ b/uPic.xcodeproj/xcshareddata/xcschemes/uPic.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1310"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/uPic/Managers/ConfigManager.swift
+++ b/uPic/Managers/ConfigManager.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 import Cocoa
-import LoginServiceKit
+import LaunchAtLogin
 
 public class ConfigManager {
     
@@ -40,7 +40,7 @@ public class ConfigManager {
         
         self.setHostItems(items: [Host.getDefaultHost()])
         
-        LoginServiceKit.removeLoginItems()
+        LaunchAtLogin.isEnabled = false
     }
     
     

--- a/uPic/Models/Github/GithubHostConfig.swift
+++ b/uPic/Models/Github/GithubHostConfig.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2019 Svend Jin. All rights reserved.
 //
 
-import Foundation
+import AppKit
 import SwiftyJSON
 
 @objcMembers

--- a/uPic/Models/Github/GithubHostConfig.swift
+++ b/uPic/Models/Github/GithubHostConfig.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2019 Svend Jin. All rights reserved.
 //
 
-import AppKit
+import Cocoa
 import SwiftyJSON
 
 @objcMembers

--- a/uPic/Models/HostConfig.swift
+++ b/uPic/Models/HostConfig.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2019 Svend Jin. All rights reserved.
 //
 
-import Foundation
+import AppKit
 import SwiftyJSON
 
 @objcMembers

--- a/uPic/Models/HostConfig.swift
+++ b/uPic/Models/HostConfig.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2019 Svend Jin. All rights reserved.
 //
 
-import AppKit
+import Cocoa
 import SwiftyJSON
 
 @objcMembers

--- a/uPic/StatusMenuController.swift
+++ b/uPic/StatusMenuController.swift
@@ -428,7 +428,7 @@ extension StatusMenuController {
             return
         }
         
-        item.keyEquivalent = shortcut.keyCodeStringForKeyEquivalent
+        item.keyEquivalent = shortcut.keyCodeStringForKeyEquivalent ?? ""
         item.keyEquivalentModifierMask = shortcut.modifierFlags
     }
 }

--- a/uPic/Views/PreferencesWindow/GeneralPreferencesViewController.swift
+++ b/uPic/Views/PreferencesWindow/GeneralPreferencesViewController.swift
@@ -7,7 +7,7 @@
 //
 
 import Cocoa
-import LoginServiceKit
+import LaunchAtLogin
 
 class GeneralPreferencesViewController: PreferencesViewController {
 
@@ -31,11 +31,7 @@ class GeneralPreferencesViewController: PreferencesViewController {
     }
 
     @IBAction func launchButtonClicked(_ sender: NSButton) {
-        if sender.state == .on {
-            LoginServiceKit.addLoginItems()
-        } else if sender.state == .off {
-            LoginServiceKit.removeLoginItems()
-        }
+        LaunchAtLogin.isEnabled = sender.state == .on ? true : false
     }
 
     @IBAction func didClickDownloadOnAppStoreButton(_ sender: NSButton) {
@@ -44,6 +40,6 @@ class GeneralPreferencesViewController: PreferencesViewController {
         }
     }
     func refreshButtonState() {
-        launchButton.state = LoginServiceKit.isExistLoginItems() ? .on : .off
+        launchButton.state = LaunchAtLogin.isEnabled == true ? .on : .off
     }
 }


### PR DESCRIPTION
1. 替换部分pod库为SPM包
2. https://github.com/Clipy/LoginServiceKit 替换为 https://github.com/sindresorhus/LaunchAtLogin
3. 最低运行版本从macOS 10.12改为macOS 10.15（老版本不好维护，几十个❌）

能build且能运行，其他的我不管，具体功能没测试，以上改动后是否有bug未知