### PR TITLE
🐛 Fix the problem of gitee upload error 403

### DIFF
--- a/uPic/Models/Gitee/GiteeUploader.swift
+++ b/uPic/Models/Gitee/GiteeUploader.swift
@@ -47,7 +47,6 @@ class GiteeUploader: BaseUploader {
         
         var headers = HTTPHeaders()
         headers.add(HTTPHeader.contentType("application/json"))
-        headers.add(HTTPHeader.defaultUserAgent)
         
         AF.request(url, method: .post, parameters: parameters, encoding: JSONEncoding.default, headers: headers).validate().uploadProgress { progress in
             super.progress(percent: progress.fractionCompleted)


### PR DESCRIPTION
gitee图床上传图片失败，抓包如下：
显示403Forbidden
<img width="600" alt="image" src="https://github.com/gee1k/uPic/assets/59362976/518e0dc4-0e01-4634-813c-88a196bd8511">
排查原因，修改请求参数：
移除默认User-Agent后上传成功：
<img width="600" alt="image" src="https://github.com/gee1k/uPic/assets/59362976/0836cc89-f3c8-45d9-bfe9-9a21fe29a4f7">
响应正常：
<img width="600" alt="image" src="https://github.com/gee1k/uPic/assets/59362976/58e6806f-18e8-4b02-9a18-934e843de95a">
Gitee 官方文档POST样例（Default无UA）：
<img width="600" alt="image" src="https://github.com/gee1k/uPic/assets/59362976/5cd8b41d-4a3b-47b5-bb65-929fa14185e9">

