### PR TITLE
feat: 迁移 SM.MS 到 S.EE 新 API

### DIFF
--- a/uPic/Models/Smms/SmmsUploader.swift
+++ b/uPic/Models/Smms/SmmsUploader.swift
@@ -16,7 +16,7 @@ class SmmsUploader: BaseUploader {
 
     static let fileExtensions: [String] = ["jpeg", "jpg", "png", "gif", "bmp"]
     
-    let url = "https://smms.app/api/v2/upload"
+    let url = "https://s.ee/api/v1/file/upload"
 
     func _upload(_ fileUrl: URL?, fileData: Data?, host: Host) {
         guard let data = host.data, let config = data as? SmmsHostConfig else {
@@ -42,15 +42,15 @@ class SmmsUploader: BaseUploader {
         
         var headers: HTTPHeaders = HTTPHeaders()
         headers.add(HTTPHeader.contentType("multipart/form-data"))
-        headers.add(name: "referer", value: "https://sm.ms/")
-        headers.add(name: "origin", value: "https://sm.ms")
+        headers.add(name: "referer", value: "https://s.ee/")
+        headers.add(name: "origin", value: "https://s.ee")
         headers.add(HTTPHeader.authorization(token))
         
         func multipartFormDataGen(multipartFormData: MultipartFormData) {
             if retData != nil {
-                multipartFormData.append(retData!, withName: "smfile", fileName: fileName, mimeType: mimeType)
+                multipartFormData.append(retData!, withName: "file", fileName: fileName, mimeType: mimeType)
             } else if fileUrl != nil {
-                multipartFormData.append(fileUrl!, withName: "smfile", fileName: fileName, mimeType: mimeType)
+                multipartFormData.append(fileUrl!, withName: "file", fileName: fileName, mimeType: mimeType)
             }
         }
 
@@ -60,18 +60,16 @@ class SmmsUploader: BaseUploader {
             switch response.result {
             case .success(let value):
                 let json = JSON(value)
-                let success = json["success"].intValue
-                if 0 == success {
-                    if json["code"] == "image_repeated", let repeatedUrl = json["images"].string {
-                        super.completed(url: repeatedUrl, retData, fileUrl, nil)
-                    } else {
-                        let msg = json["message"].stringValue
-                        super.faild(responseData: response.data, errorMsg: msg)
-                    }
-                } else {
+                let code = json["code"].intValue
+                if 0 == code {
+                    // Success - S.EE API uses code: 0 for success
                     let data = json["data"]
                     let url = data["url"].stringValue
                     super.completed(url: url, retData, fileUrl, nil)
+                } else {
+                    // Error - handle both old SM.MS format and new S.EE format
+                    let msg = json["message"].stringValue
+                    super.faild(responseData: response.data, errorMsg: msg)
                 }
             case .failure(_):
                 super.faild(responseData: response.data)

--- a/uPic/Views/PreferencesWindow/ConfigView/Views/SmmsConfigView.swift
+++ b/uPic/Views/PreferencesWindow/ConfigView/Views/SmmsConfigView.swift
@@ -57,7 +57,7 @@ class SmmsConfigView: ConfigView {
     }
     
     @objc func getApiToken(_ sender: NSButton) {
-        guard let url = URL(string: "https://smms.app/home/apitoken") else {
+        guard let url = URL(string: "https://s.ee/user/settings") else {
             return
         }
         NSWorkspace.shared.open(url)


### PR DESCRIPTION
- 更新 API 端点从 smms.app 到 s.ee
- 更新请求头 referer 和 origin
- 更新表单字段名从 smfile 到 file
- 适配新的响应格式（code: 0 表示成功）
- 更新获取 API Token 的链接地址

根据 SM.MS 官方迁移通知，所有服务已迁移至 S.EE 平台。
此更新确保 uPic 能够继续正常使用图床服务。

## Summary of this pull request

## Does this solve an existing issue? If so, add a link to it

## Steps to test this feature

## Screenshots

## Additional info
